### PR TITLE
add gitignore file to erase .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
add .gitignore in the local folder to avoid MacOS adding .DS_Store files into the repo from now on